### PR TITLE
Really small correction in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,8 @@ Fandjango provides a template tag for loading and initializing Facebook's JavaSc
     {% load facebook %}
     
     {% facebook_init %}
-        # This code will be run once the JavaScript SDK has been loaded and initialized.
-        alert('It worked!')
+        // This code will be run once the JavaScript SDK has been loaded and initialized.
+        alert('It worked!');
     {% endfacebook %}
         
 ## Installation


### PR DESCRIPTION
Hey Johannes,
Thanks for your work, it saved me a lot of time.

I found a little syntax error in the javascript part of the template tag example in the README. As someone who hardly ever does frontend programming, I could imagine that there are more people who don't immediately understand why - in this case - the alert isn't shown, while using the example code. (At least Chrome states "Uncaught SyntaxError: Unexpected token ILLEGAL" about the comment with an #.)

Cheers,
Erwin
