### PR TITLE
IE fails to redirect to authorize page

### DIFF
--- a/fandjango/views.py
+++ b/fandjango/views.py
@@ -37,7 +37,7 @@ def authorize_application(
         dictionary = {
             'url': 'https://www.facebook.com/dialog/oauth?%s' % urlencode(query)
         },
-        status = 303
+        status = 200
     )
 
 def authorization_denied(request):


### PR DESCRIPTION
Currently when Fandjango redirects a user to authorize the app, it uses a HTTP status code of 303.  The body of the response contains the javascript "window.parent.location = "{{ url|safe }}".  The response also leaves the Location header blank, which is typically accompanied with a 303.

This works perfectly fine for every browser...except IE.  I've no doubt you're as shocked as I am.

So this pull request sets the status code to a 200, a quick and simple fix.  Since you have the request you could also try to detect MSIE in the user agent.  The code could look something like this:

```
status_code = 303
if re.search(r'MSIE [^\s]+;', request.META.get('HTTP_USER_AGENT', '')):
    status_code = 200

return render(
    request = request,
    template_name = 'fandjango/authorize_application.html',
    dictionary = {
        'url': 'https://graph.facebook.com/oauth/authorize?%s' % urlencode(query)
    },
    status = status_code,
)
```

Let me know what you're thoughts are.  Here's a list of IE agents for testing if you're interested:

```
test_user_agents = [
    'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; WOW64; Trident/6.0)',
    'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/5.0)',
    'Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 7.1; Trident/5.0)',
    'Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0; chromeframe/11.0.696.57)',
    'Mozilla/5.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; .NET CLR 1.1.4322; .NET CLR 2.0.50727)',
    'Mozilla/4.0 (compatible; MSIE 7.0b; Windows NT 6.0)',
    'Mozilla/5.0 (Windows; U; MSIE 7.0; Windows NT 5.2)',
    'Mozilla/4.0 (compatible;MSIE 7.0;Windows NT 6.0)',
    'Mozilla/4.0 (compatible; MSIE 6.1; Windows XP; .NET CLR 1.1.4322; .NET CLR 2.0.50727)',
    'Mozilla/4.0 (compatible; MSIE 6.01; Windows NT 6.0)',
    'Mozilla/4.0 (compatible; MSIE 6.0b; Windows NT 5.1)',
    'Mozilla/5.0 (compatible; MSIE 6.0; Windows NT 5.1)',
    'Mozilla/4.01 (compatible; MSIE 6.0; Windows NT 5.1)',
    'Mozilla/4.0 (compatible; MSIE 5.5b1; Mac_PowerPC)'
]
```
