### PR TITLE
A way to turn off saving the signed request cookie.

### DIFF
--- a/fandjango/middleware.py
+++ b/fandjango/middleware.py
@@ -7,7 +7,8 @@ from django.core.exceptions import ImproperlyConfigured
 
 from fandjango.views import authorize_application, authorization_denied
 from fandjango.models import Facebook, User, OAuthToken
-from fandjango.settings import FACEBOOK_APPLICATION_SECRET_KEY, FACEBOOK_APPLICATION_ID, DISABLED_PATHS, ENABLED_PATHS
+from fandjango.settings import FACEBOOK_APPLICATION_SECRET_KEY, FACEBOOK_APPLICATION_ID, FACEBOOK_SIGNED_REQUEST_COOKIE,\
+                                DISABLED_PATHS, ENABLED_PATHS
 from fandjango.utils import (
     is_disabled_path, is_enabled_path,
     authorization_denied_view, get_post_authorization_redirect_url
@@ -30,7 +31,7 @@ class FacebookMiddleware():
         if ENABLED_PATHS and not is_enabled_path(request.path):
             return
 
-        # An error occured during authorization...        
+        # An error occured during authorization...
         if 'error' in request.GET:
             error = request.GET['error']
 
@@ -126,7 +127,9 @@ class FacebookMiddleware():
         browsers it is considered by IE before accepting third-party cookies (ie. cookies set by
         documents in iframes). If they are not set correctly, IE will not set these cookies.
         """
-        if 'signed_request' in request.REQUEST:
-            response.set_cookie('signed_request', request.REQUEST['signed_request'])
-        response['P3P'] = 'CP="IDC CURa ADMa OUR IND PHY ONL COM STA"'
+        if FACEBOOK_SIGNED_REQUEST_COOKIE:
+            if 'signed_request' in request.REQUEST:
+                response.set_cookie('signed_request', request.REQUEST['signed_request'])
+            response['P3P'] = 'CP="IDC CURa ADMa OUR IND PHY ONL COM STA"'
         return response
+

--- a/fandjango/settings.py
+++ b/fandjango/settings.py
@@ -29,3 +29,7 @@ FACEBOOK_APPLICATION_INITIAL_PERMISSIONS = getattr(settings, 'FACEBOOK_APPLICATI
 
 # A string describing the Facebook's application's domain
 FACEBOOK_APPLICATION_DOMAIN = getattr(settings, 'FACEBOOK_APPLICATION_DOMAIN', 'apps.facebook.com')
+
+# A boolean to determine if must save signed request to a cookie.
+FACEBOOK_SIGNED_REQUEST_COOKIE = getattr(settings, 'FACEBOOK_SIGNED_REQUEST_COOKIE', True)
+


### PR DESCRIPTION
The normal situation can be modified for applications running inside a page tab which cookies aren't useful.
