### PR TITLE
Make all DateTime objects aware

### DIFF
--- a/fandjango/middleware.py
+++ b/fandjango/middleware.py
@@ -1,6 +1,3 @@
-from datetime import datetime
-import time
-
 from django.conf import settings
 from django.http import QueryDict
 from django.core.exceptions import ImproperlyConfigured
@@ -17,6 +14,13 @@ from fandjango.utils import (
 )
 
 from facepy import SignedRequest, GraphAPI
+
+try:
+    from django.utils.timezone import now
+except ImportError:
+    from datetime.datetime import now
+
+from dateutil.tz import tzlocal
 
 class FacebookMiddleware():
     """Middleware for Facebook applications."""
@@ -84,8 +88,8 @@ class FacebookMiddleware():
                 except User.DoesNotExist:
                     oauth_token = OAuthToken.objects.create(
                         token = request.facebook.signed_request.user.oauth_token.token,
-                        issued_at = request.facebook.signed_request.user.oauth_token.issued_at,
-                        expires_at = request.facebook.signed_request.user.oauth_token.expires_at
+                        issued_at = request.facebook.signed_request.user.oauth_token.issued_at.replace(tzinfo=tzlocal()),
+                        expires_at = request.facebook.signed_request.user.oauth_token.expires_at.replace(tzinfo=tzlocal())
                     )
 
                     user = User.objects.create(
@@ -97,15 +101,15 @@ class FacebookMiddleware():
 
                 # Update the user's details and OAuth token
                 else:
-                    user.last_seen_at = datetime.now()
+                    user.last_seen_at = now()
 
                     if 'signed_request' in request.REQUEST:
                         user.authorized = True
 
                         if request.facebook.signed_request.user.oauth_token:
                             user.oauth_token.token = request.facebook.signed_request.user.oauth_token.token
-                            user.oauth_token.issued_at = request.facebook.signed_request.user.oauth_token.issued_at
-                            user.oauth_token.expires_at = request.facebook.signed_request.user.oauth_token.expires_at
+                            user.oauth_token.issued_at = request.facebook.signed_request.user.oauth_token.issued_at.replace(tzinfo=tzlocal())
+                            user.oauth_token.expires_at = request.facebook.signed_request.user.oauth_token.expires_at.replace(tzinfo=tzlocal())
                             user.oauth_token.save()
 
                     user.save()

--- a/fandjango/models.py
+++ b/fandjango/models.py
@@ -12,6 +12,11 @@ from facepy import GraphAPI
 
 import requests
 
+try:
+    from django.utils.timezone import now
+except ImportError:
+    from datetime.datetime import now
+
 class Facebook:
     """
     Facebook instances hold information on the current user and
@@ -241,7 +246,7 @@ class OAuthToken(models.Model):
     @property
     def expired(self):
         """Determine whether the OAuth token has expired."""
-        return self.expires_at < datetime.now() if self.expires_at else False
+        return self.expires_at < now() if self.expires_at else False
 
     @property
     def extended(self):
@@ -265,7 +270,7 @@ class OAuthToken(models.Model):
         components = parse_qs(response)
 
         self.token = components['access_token'][0]
-        self.expires_at = datetime.now() + timedelta(seconds = int(components['expires'][0]))
+        self.expires_at = now() + timedelta(seconds = int(components['expires'][0]))
 
         self.save()
 

--- a/tests/test_fandjango.py
+++ b/tests/test_fandjango.py
@@ -1,6 +1,6 @@
 from nose.tools import with_setup
 
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 from django.test.client import Client
 from django.test.client import RequestFactory
@@ -16,6 +16,11 @@ from fandjango.utils import get_post_authorization_redirect_url
 from .helpers import assert_contains
 
 from facepy import GraphAPI, SignedRequest
+
+try:
+    from django.utils.timezone import now
+except ImportError:
+    from datetime.datetime import now
 
 TEST_APPLICATION_ID     = '181259711925270'
 TEST_APPLICATION_SECRET = '214e4cb484c28c35f18a70a3d735999b'
@@ -151,7 +156,7 @@ def test_signed_request_renewal():
     client = Client()
 
     signed_request = SignedRequest(TEST_SIGNED_REQUEST, TEST_APPLICATION_SECRET)
-    signed_request.user.oauth_token.expires_at = datetime.now() - timedelta(days=1)
+    signed_request.user.oauth_token.expires_at = now() - timedelta(days=1)
 
     response = client.get(
         path = reverse('home'),


### PR DESCRIPTION
Django versions > 1.4 will complain if the DateTime objects used are not "aware" (do not contain timezone and daylight saving time information). Changes include using `django.utils.timezone.now` instead of `datetime.datetime.now` (when available) and setting the local timezone to `OAuthToken` datetime variables coming in from facepy.
