### PR TITLE
Fix for django.conf.urls.defaults removed in 1.6

### DIFF
--- a/fandjango/urls.py
+++ b/fandjango/urls.py
@@ -1,4 +1,7 @@
-from django.conf.urls.defaults import *
+try:
+    from django.conf.urls.defaults import patterns, url
+except:
+    from django.conf.urls import patterns, url
 
 from views import *
 


### PR DESCRIPTION
Thanks to this commit fandjango runs on Django 1.6.
