### PR TITLE
Added canvas https setting for those that need it. 

### DIFF
--- a/fandjango/settings.py
+++ b/fandjango/settings.py
@@ -8,6 +8,9 @@ FACEBOOK_APPLICATION_ID = getattr(settings, 'FACEBOOK_APPLICATION_ID')
 # A string describing the Facebook application's canvas URL.
 FACEBOOK_APPLICATION_CANVAS_URL = getattr(settings, 'FACEBOOK_APPLICATION_CANVAS_URL', None)
 
+# A canvas URL https boolean
+FACEBOOK_APPLICATION_CANVAS_URL_IS_HTTPS = getattr(settings, 'FACEBOOK_APPLICATION_CANVAS_URL_IS_HTTPS', False)
+
 # A string describing the URL to redirect to upon authorizing users.
 FACEBOOK_AUTHORIZATION_REDIRECT_URL = getattr(settings, 'FACEBOOK_AUTHORIZATION_REDIRECT_URL', None)
 

--- a/fandjango/utils.py
+++ b/fandjango/utils.py
@@ -7,6 +7,7 @@ from django.core.cache import cache
 from django.utils.importlib import import_module
 
 from fandjango.settings import FACEBOOK_APPLICATION_CANVAS_URL
+from fandjango.settings import FACEBOOK_APPLICATION_CANVAS_URL_IS_HTTPS
 from fandjango.settings import FACEBOOK_APPLICATION_DOMAIN
 from fandjango.settings import FACEBOOK_APPLICATION_NAMESPACE
 from fandjango.settings import DISABLED_PATHS
@@ -84,10 +85,16 @@ def get_post_authorization_redirect_url(request, canvas=True):
     path = request.get_full_path()
 
     if canvas:
+
         if FACEBOOK_APPLICATION_CANVAS_URL:
             path = path.replace(urlparse(FACEBOOK_APPLICATION_CANVAS_URL).path, '')
 
-        redirect_uri = 'http://%(domain)s/%(namespace)s%(path)s' % {
+        scheme = 'http'
+        if FACEBOOK_APPLICATION_CANVAS_URL_IS_HTTPS:
+            scheme = 'https'
+
+        redirect_uri = '%(scheme)s://%(domain)s/%(namespace)s%(path)s' % {
+            'scheme': scheme,
             'domain': FACEBOOK_APPLICATION_DOMAIN,
             'namespace': FACEBOOK_APPLICATION_NAMESPACE,
             'path': path


### PR DESCRIPTION
FACEBOOK_APPLICATION_CANVAS_URL_IS_HTTPS for creating the redirect_uri
in get_post_authorization_redirect_url.
